### PR TITLE
Use Node.js version 24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,5 +17,5 @@ outputs:
   sha:
     description: 'shortened SHA'
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'


### PR DESCRIPTION
Make sure the action also works in the future - and get rid of the warning now:

<img width="1462" height="329" alt="grafik" src="https://github.com/user-attachments/assets/d4933ed1-edff-4836-82ee-5f332936b469" />
